### PR TITLE
[web] Dynamic size prototype

### DIFF
--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -80,8 +80,6 @@ abstract class PlatformDispatcher {
 
   void scheduleFrame();
 
-  void render(Scene scene, [FlutterView view]);
-
   AccessibilityFeatures get accessibilityFeatures;
 
   VoidCallback? get onAccessibilityFeaturesChanged;

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -709,8 +709,13 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   ///    scheduling of frames.
   ///  * [RendererBinding], the Flutter framework class which manages layout and
   ///    painting.
-  @override
-  void render(ui.Scene scene, [ui.FlutterView? view]) {
+  void render(ui.Scene scene, { ui.FlutterView? view, ui.Size? size }) {
+    if (size != null && view is EngineFlutterView) {
+      view.dom.rootElement.style
+        ..width = '${size.width / view.devicePixelRatio}px'
+        ..height = '${size.height / view.devicePixelRatio}px';
+        // The hostElement of the app should reflow according to this new size.
+    }
     renderer.renderScene(scene);
   }
 

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -99,6 +99,17 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow implements EngineFlu
   BrowserHistory?
       _browserHistory; // Must be either SingleEntryBrowserHistory or MultiEntriesBrowserHistory.
 
+  @override
+  void render(ui.Scene scene, {ui.FlutterView? view, ui.Size? size}) {
+    // This render method probably needs to be owned by some ViewRenderer
+    // attribute of the view.
+    platformDispatcher.render(
+      scene,
+      view: this,
+      size: size,
+    );
+  }
+
   Future<void> _useSingleEntryBrowserHistory() async {
     // Recreate the browser history mode that's appropriate for the existing
     // history state.

--- a/lib/web_ui/lib/window.dart
+++ b/lib/web_ui/lib/window.dart
@@ -24,7 +24,7 @@ abstract class FlutterView {
   GestureSettings get gestureSettings;
   List<DisplayFeature> get displayFeatures;
   Display get display;
-  void render(Scene scene) => platformDispatcher.render(scene, this);
+  void render(Scene scene, { Size? size });
   void updateSemantics(SemanticsUpdate update) => platformDispatcher.updateSemantics(update);
 }
 
@@ -103,9 +103,6 @@ abstract class SingletonFlutterWindow extends FlutterView {
   String get defaultRouteName => platformDispatcher.defaultRouteName;
 
   void scheduleFrame() => platformDispatcher.scheduleFrame();
-
-  @override
-  void render(Scene scene) => platformDispatcher.render(scene, this);
 
   bool get semanticsEnabled => platformDispatcher.semanticsEnabled;
 


### PR DESCRIPTION
Changes required so view.render can resize the HTML element that contains the Flutter app.

(Some things have to do with web's platform_dispatcher getting out of sync with dart:ui).
